### PR TITLE
Bump Bio-Tracks version to 0.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-biotracks==0.4.0
+biotracks==0.4.1
 isatools
 pandas
 seaborn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
-datapackage
+biotracks==0.4.0
 isatools
-jsontableschema
-jsontableschema-pandas
 pandas
 seaborn
 tabulator
 xlrd
-biotracks>=0.3.0


### PR DESCRIPTION
- Also remove duplicate dependencies resolved transitively

While working on #4, I realized that the current Docker image built from this repository was failing making it a non-started for e.g. using https://mybinder.org/. As it turns out, this was related to the upstream changes made in the  `datapackage` library. The latter was capped in https://github.com/CellMigStandOrg/biotracks/pull/53 and released as `biotracks 0.4.0`.

With this PR included, Travis should turn green while a rebuild of the current `master` branch should show it is failing with the current state of `requirements.txt`.